### PR TITLE
Fix barred glass & barred glass pane item tags

### DIFF
--- a/common/src/main/resources/data/hearth_and_home/tags/items/barred_glass.json
+++ b/common/src/main/resources/data/hearth_and_home/tags/items/barred_glass.json
@@ -1,6 +1,6 @@
 {
 	"values": [
-		"hearth_and_home:barred_glass_pane",
-		"#hearth_and_home:stained_barred_glass_panes"
+		"hearth_and_home:barred_glass",
+		"#hearth_and_home:stained_barred_glass"
 	]
 }

--- a/common/src/main/resources/data/hearth_and_home/tags/items/barred_glass_panes.json
+++ b/common/src/main/resources/data/hearth_and_home/tags/items/barred_glass_panes.json
@@ -1,6 +1,6 @@
 {
 	"values": [
-		"hearth_and_home:barred_glass",
-		"#hearth_and_home:stained_barred_glass"
+		"hearth_and_home:barred_glass_pane",
+		"#hearth_and_home:stained_barred_glass_panes"
 	]
 }


### PR DESCRIPTION
The tags were attached to the opposite items. Barred glass had `barred_glass_panes` attached to it, and barred glass panes had `barred_glass` attached to them